### PR TITLE
Configurando o fluxo Authorization Server com Password Credentials e Opaque Tokens

### DIFF
--- a/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
@@ -1,11 +1,38 @@
 package com.course.springfood.auth;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 
 @Configuration
 @EnableAuthorizationServer
 public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdapter {
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Override
+    public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+        clients
+                .inMemory()
+                .withClient("springfood-web")
+                .secret(passwordEncoder.encode("web123"))
+                .authorizedGrantTypes("password")
+                .scopes("write", "read")
+                .accessTokenValiditySeconds(60 * 60 * 6); // 6 horas (padrão é 12 horas)
+    }
+
+    @Override
+    public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
+        endpoints.authenticationManager(authenticationManager);
+    }
 
 }

--- a/src/main/java/com/course/springfood/auth/WebSecurityConfig.java
+++ b/src/main/java/com/course/springfood/auth/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.course.springfood.auth;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -27,6 +28,12 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    @Override
+    protected AuthenticationManager authenticationManager() throws Exception {
+        return super.authenticationManager();
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.port=8081


### PR DESCRIPTION
### Resource Owner Password Credentials
Para um "client" se autenticar no Authorization Server, é necessário informar seu "clienteId" e "secret" (no exemplo "springfood-web" e "web123") nos campos de autenticação (utilizando o Postman é necessário informar em "Authorization" o tipo de autenticação "Basic Auth" e informar o clientId e secret do client). Também é necessário informar o Body da requisição como "x-www-form-urlencoded" e informar as informações de login do usuário que deseja autenticação (Resource Owner) informando o "username", o "password" e o "grant_type" (como "password") que no exemplo foram informados em memória na aplicação. 
Para realizar a autenticação e obter um token, é necessário uma requisição POST para a URI: http://localhost:8081/oauth/token