### PR TITLE
Configurando o endpoint de introspecção de tokens no Authorization Server

### DIFF
--- a/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.oauth2.config.annotation.configurers.ClientD
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 
 @Configuration
 @EnableAuthorizationServer
@@ -28,6 +29,12 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
                 .authorizedGrantTypes("password")
                 .scopes("write", "read")
                 .accessTokenValiditySeconds(60 * 60 * 6); // 6 horas (padrão é 12 horas)
+    }
+
+    @Override
+    public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
+//		security.checkTokenAccess("isAuthenticated()");
+        security.checkTokenAccess("permitAll()");
     }
 
     @Override


### PR DESCRIPTION
### Introspecção de tokens
Quando o Client faz uma requisição em recurso da API usando access token, o Resource Server valida esse token no Authorization Server. Essa troca de informação entre o Resource Server e o Authorization Server para validar e verificar o estado atual do token é chamada de "introspecção de token".

Para realizar a introspecção do token, é necessário realizar uma requisição POST para a URI http://localhost:8081/oauth/token
Obs: O Body da requisição deve ser do tipo "x-www-form-urlencoded" e possuir um parâmetro chamado "token" informando qual o token para validar.