### PR TITLE
Configurando Client Credentials Grant Type

### DIFF
--- a/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
@@ -31,9 +31,17 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
                 .withClient("springfood-web")
                 .secret(passwordEncoder.encode("web123"))
                 .authorizedGrantTypes("password", "refresh_token")
+//				.authorizedGrantTypes("password", "refresh_token", "client_credentials")
                 .scopes("write", "read")
                 .accessTokenValiditySeconds(6 * 60 * 60)// 6 horas
                 .refreshTokenValiditySeconds(60 * 24 * 60 * 60) // 60 dias
+
+                .and()
+                .withClient("faturamento")
+                .secret(passwordEncoder.encode("faturamento123"))
+                .authorizedGrantTypes("client_credentials")
+                .scopes("write", "read")
+
                 .and()
                 .withClient("checktoken")
                 .secret(passwordEncoder.encode("check123"));


### PR DESCRIPTION
Para gerar um novo access token, é necessário realizar uma requisição POST para a URI http://localhost:8081/oauth/token
Obs: O Body da requisição deve ser do tipo "x-www-form-urlencoded" e possuir um parâmetro chamado "grant_type" informando o valor "client_credentials". A requisição deve ter autenticação básica, utilizando o login/senha do client.