### PR TITLE
Configurando Authorization Code Grant Type

### DIFF
--- a/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
@@ -26,23 +26,29 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
 
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
-        clients
-                .inMemory()
+        clients.
+            inMemory()
                 .withClient("springfood-web")
                 .secret(passwordEncoder.encode("web123"))
                 .authorizedGrantTypes("password", "refresh_token")
-//				.authorizedGrantTypes("password", "refresh_token", "client_credentials")
                 .scopes("write", "read")
                 .accessTokenValiditySeconds(6 * 60 * 60)// 6 horas
                 .refreshTokenValiditySeconds(60 * 24 * 60 * 60) // 60 dias
 
-                .and()
+            .and()
+                .withClient("foodnanalytics")
+                .secret(passwordEncoder.encode("food123"))
+                .authorizedGrantTypes("authorization_code")
+                .scopes("write", "read")
+                .redirectUris("http://aplicacao-cliente")
+
+            .and()
                 .withClient("faturamento")
                 .secret(passwordEncoder.encode("faturamento123"))
                 .authorizedGrantTypes("client_credentials")
                 .scopes("write", "read")
 
-                .and()
+            .and()
                 .withClient("checktoken")
                 .secret(passwordEncoder.encode("check123"));
     }

--- a/src/main/java/com/course/springfood/auth/WebSecurityConfig.java
+++ b/src/main/java/com/course/springfood/auth/WebSecurityConfig.java
@@ -29,7 +29,12 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf().disable();  //Desativado CSRF
+        http
+            .csrf().disable()
+            .authorizeRequests()
+                .anyRequest().authenticated()
+            .and()
+                .formLogin().permitAll();
     }
 
     @Bean


### PR DESCRIPTION
Para gerar um novo "code" (que será utilizado posteriormente para obter um access token), é necessário realizar uma requisição (GET pelo navegador ou uma aplicação) para a URI :
http://localhost:8081/oauth/authorize?response_type=code&client_id=id_do_cliente&state=abc&redirect_uri=https://CLIENTE/

Ex: http://localhost:8081/oauth/authorize?response_type=code&client_id=foodnanalytics&state=abc&redirect_uri=http://aplicacao-cliente
Obs: Nesse momento será exibido ao usuário os recursos e a solicitação de permissão de acesso nos mesmos.

Para gerar um novo access token (após obter o "code"), é necessário realizar uma requisição POST para a URI http://localhost:8081/oauth/token
Obs: A requisição deve ter Basic Auth (informando as credenciais do Client) e o Body da requisição deve ser do tipo "x-www-form-urlencoded" e possuir os parâmetros: "code" (informando qual o code recebido), "grant_type" (informando o valor "authorization_code") e "redirect_uri" (que é o link de redirecionamento para o client mas aqui será utilizado somente para validação).
Obs 2: Após utilizar o "code" (código de acesso) tendo sucesso (ou não) na tentativa de gerar o access token, ele será inutilizado.