### PR TITLE
Implementando o suporte a PKCE com o fluxo Authorization Code

### DIFF
--- a/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
@@ -10,6 +10,10 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.A
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableAuthorizationServer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.CompositeTokenGranter;
+import org.springframework.security.oauth2.provider.TokenGranter;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableAuthorizationServer
@@ -37,7 +41,7 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
 
             .and()
                 .withClient("foodnanalytics")
-                .secret(passwordEncoder.encode("food123"))
+                .secret(passwordEncoder.encode(""))
                 .authorizedGrantTypes("authorization_code")
                 .scopes("write", "read")
                 .redirectUris("http://localhost:8082")
@@ -62,7 +66,8 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
     @Override
     public void configure(AuthorizationServerSecurityConfigurer security) throws Exception {
 //		security.checkTokenAccess("isAuthenticated()");
-        security.checkTokenAccess("permitAll()");
+        security.checkTokenAccess("permitAll()")
+                .allowFormAuthenticationForClients();
     }
 
     @Override
@@ -70,7 +75,19 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
         endpoints
                 .authenticationManager(authenticationManager)
                 .userDetailsService(userDetailsService)
-                .reuseRefreshTokens(false);
+                .reuseRefreshTokens(false)
+                .tokenGranter(tokenGranter(endpoints));
+    }
+
+    private TokenGranter tokenGranter(AuthorizationServerEndpointsConfigurer endpoints) {
+        var pkceAuthorizationCodeTokenGranter = new PkceAuthorizationCodeTokenGranter(endpoints.getTokenServices(),
+                endpoints.getAuthorizationCodeServices(), endpoints.getClientDetailsService(),
+                endpoints.getOAuth2RequestFactory());
+
+        var granters = Arrays.asList(
+                pkceAuthorizationCodeTokenGranter, endpoints.getTokenGranter());
+
+        return new CompositeTokenGranter(granters);
     }
 
 }

--- a/src/main/java/com/course/springfood/auth/PkceAuthorizationCodeTokenGranter.java
+++ b/src/main/java/com/course/springfood/auth/PkceAuthorizationCodeTokenGranter.java
@@ -1,0 +1,70 @@
+package com.course.springfood.auth;
+
+import org.apache.commons.codec.binary.Base64;
+import org.springframework.security.crypto.codec.Utf8;
+import org.springframework.security.oauth2.common.exceptions.InvalidGrantException;
+import org.springframework.security.oauth2.provider.*;
+import org.springframework.security.oauth2.provider.code.AuthorizationCodeServices;
+import org.springframework.security.oauth2.provider.code.AuthorizationCodeTokenGranter;
+import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class PkceAuthorizationCodeTokenGranter extends AuthorizationCodeTokenGranter {
+
+    public PkceAuthorizationCodeTokenGranter(AuthorizationServerTokenServices tokenServices,
+                                             AuthorizationCodeServices authorizationCodeServices, ClientDetailsService clientDetailsService,
+                                             OAuth2RequestFactory requestFactory) {
+        super(tokenServices, authorizationCodeServices, clientDetailsService, requestFactory);
+    }
+
+    @Override
+    protected OAuth2Authentication getOAuth2Authentication(ClientDetails client, TokenRequest tokenRequest) {
+        OAuth2Authentication authentication = super.getOAuth2Authentication(client, tokenRequest);
+        OAuth2Request request = authentication.getOAuth2Request();
+
+        String codeChallenge = request.getRequestParameters().get("code_challenge");
+        String codeChallengeMethod = request.getRequestParameters().get("code_challenge_method");
+        String codeVerifier = request.getRequestParameters().get("code_verifier");
+
+        if (codeChallenge != null || codeChallengeMethod != null) {
+            if (codeVerifier == null) {
+                throw new InvalidGrantException("Code verifier expected.");
+            }
+
+            if (!validateCodeVerifier(codeVerifier, codeChallenge, codeChallengeMethod)) {
+                throw new InvalidGrantException(codeVerifier + " does not match expected code verifier.");
+            }
+        }
+
+        return authentication;
+    }
+
+    private boolean validateCodeVerifier(String codeVerifier, String codeChallenge,
+                                         String codeChallengeMethod) {
+
+        String generatedCodeChallenge = null;
+
+        if ("plain".equalsIgnoreCase(codeChallengeMethod)) {
+            generatedCodeChallenge = codeVerifier;
+        } else if ("s256".equalsIgnoreCase(codeChallengeMethod)) {
+            generatedCodeChallenge = generateHashSha256(codeVerifier);
+        } else {
+            throw new InvalidGrantException(codeChallengeMethod + " is not a valid challenge method.");
+        }
+
+        return generatedCodeChallenge.equals(codeChallenge);
+    }
+
+    private static String generateHashSha256(String plainText) {
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = messageDigest.digest(Utf8.encode(plainText));
+            return Base64.encodeBase64URLSafeString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
Para gerar um novo "code" (que será utilizado posteriormente para obter um access token), é necessário realizar uma requisição (GET pelo navegador ou uma aplicação) para a URI :
https://AUTHORIZATION-SERVER/oauth/authorize?response_type=code&client_id=id_do_cliente&redirect_uri=https://CLIENTE&code_challenge=xXeEMfPlt13FbhtvG_35efIlv5qss8Y726Cncj0YV7U&code_challenge_method=s256

Ex: http://localhost:8081/oauth/authorize?response_type=code&client_id=foodnanalytics&redirect_uri=http://localhost:8082&code_challenge=xXeEMfPlt13FbhtvG_35efIlv5qss8Y726Cncj0YV7U&code_challenge_method=s256
Obs: Nesse momento será exibido ao usuário os recursos e a solicitação de permissão de acesso nos mesmos.

Após obter o código de acesso, o Client pode solicitar um Access Token ao Authorization Server. Para gerar um novo token, é necessário realizar uma requisição POST para a URI http://localhost:8081/oauth/token
Obs: A requisição não precisa realizar a autenticação do client. O Body da requisição deve ser do tipo "x-www-form-urlencoded" e possuir os parâmetros:  
"code": (informando qual o code recebido), "grant_type" (informando o valor "authorization_code"), "redirect_uri" (que é o link de redirecionamento para o client), "client_id" (o id do cliente) e "code_verifier" (a mesma String aleatória que foi gerada e convertida no Code Challenge enviado no servidor de autenticação).
Obs 2: Após utilizar o "code" (código de acesso) tendo sucesso (ou não) na tentativa de gerar o access token, ele será inutilizado.