### PR TITLE
Armazenando tokens no Redis - RedisTokenStore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
 			<artifactId>jaxb-impl</artifactId>
 			<version>${javax-jaxb.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
@@ -2,6 +2,7 @@ package com.course.springfood.auth;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -12,6 +13,8 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Aut
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.CompositeTokenGranter;
 import org.springframework.security.oauth2.provider.TokenGranter;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+import org.springframework.security.oauth2.provider.token.store.redis.RedisTokenStore;
 
 import java.util.Arrays;
 
@@ -27,6 +30,9 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
 
     @Autowired
     private UserDetailsService userDetailsService;
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
 
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
@@ -76,7 +82,12 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
                 .authenticationManager(authenticationManager)
                 .userDetailsService(userDetailsService)
                 .reuseRefreshTokens(false)
+                .tokenStore(redisTokenStore())
                 .tokenGranter(tokenGranter(endpoints));
+    }
+
+    private TokenStore redisTokenStore() {
+        return new RedisTokenStore(redisConnectionFactory);
     }
 
     private TokenGranter tokenGranter(AuthorizationServerEndpointsConfigurer endpoints) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 server.port=8081
+
+spring.redis.host=localhost
+spring.redis.password=
+spring.redis.port=6379


### PR DESCRIPTION
Se a aplicação guardar o token na memória e houver mais de uma instância, podem ocorrer problemas na validação do token. Para isso, é indicado realizar o armazenamento dos tokens centralizado (como um banco de dados SQL, NoSQL ou algum que tenha persistência um tempo maior que não seja na memória da instância da aplicação).