### PR TITLE
Configurando o Resource Server para JWT assinado com chave simétrica

### DIFF
--- a/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
+++ b/src/main/java/com/course/springfood/auth/AuthorizationServerConfig.java
@@ -85,7 +85,7 @@ public class AuthorizationServerConfig extends AuthorizationServerConfigurerAdap
     @Bean
     public JwtAccessTokenConverter jwtAccessTokenConverter() {
         JwtAccessTokenConverter jwtAccessTokenConverter = new JwtAccessTokenConverter();
-        jwtAccessTokenConverter.setSigningKey("springfood");
+        jwtAccessTokenConverter.setSigningKey("YXV0aG9yaXphdGlvbmRqYWxtYXNwcmluZ2Zvb2Q");
 
         return jwtAccessTokenConverter;
     }


### PR DESCRIPTION
Para utilizar o **JWT** é necessário que a "secret" tenha **256 bits** (32 bytes).

Obs: geralmente caracteres normais tem 1 byte e caracteres especiais 2 bytes.

Obs 2: utilizei o site "https://base64.guru/standards/base64url/encode" para converter a palavra "authorizationdjalmaspringfood" para base64url e utilizar como secret.

Obs 3: para desconverter base64url para string: "https://base64.guru/standards/base64url/decode".